### PR TITLE
Create randomisation call for optimal_matching

### DIFF
--- a/R/funs_with_without_repla.R
+++ b/R/funs_with_without_repla.R
@@ -26,7 +26,7 @@ iterations_per_round_random <- function(dataset, cluster_var, Id_Patient, total_
     Id_Patient <- enquo(Id_Patient)
     total_cont_per_case <- enquo(total_cont_per_case)
 
-    one_to_one = dataset %>% group_by((!!cluster_var)) %>% slice_sample(n = total_cont_per_case, replace = FALSE) %>% filter(row_number() <= 2)
+    one_to_one = dataset %>% group_by((!!cluster_var))%>% filter(row_number() <= 2) %>% slice_sample(n = 10*total_cont_per_case, replace = FALSE) 
     dup_con = one_to_one %>% distinct() %>% group_by((!!Id_Patient)) %>% filter(n() > 1) %>% arrange((!!Id_Patient), (!!total_cont_per_case)) %>% filter(row_number() ==1)
     if (nrow(dup_con) > 0) {
         one_to_one <- anti_join(one_to_one, dup_con, by = quo_name(Id_Patient))  # library(rlang) is needed

--- a/R/funs_with_without_repla.R
+++ b/R/funs_with_without_repla.R
@@ -26,7 +26,7 @@ iterations_per_round_random <- function(dataset, cluster_var, Id_Patient, total_
     Id_Patient <- enquo(Id_Patient)
     total_cont_per_case <- enquo(total_cont_per_case)
 
-    one_to_one = dataset %>% group_by((!!cluster_var))%>% filter(row_number() <= 2) %>% slice_sample(n = 10*!!total_cont_per_case, replace = FALSE) 
+    one_to_one = dataset %>% group_by((!!cluster_var))%>% filter(row_number() <= 2) %>% slice_sample(n = 100, replace = FALSE) 
     dup_con = one_to_one %>% distinct() %>% group_by((!!Id_Patient)) %>% filter(n() > 1) %>% arrange((!!Id_Patient), (!!total_cont_per_case)) %>% filter(row_number() ==1)
     if (nrow(dup_con) > 0) {
         one_to_one <- anti_join(one_to_one, dup_con, by = quo_name(Id_Patient))  # library(rlang) is needed

--- a/R/funs_with_without_repla.R
+++ b/R/funs_with_without_repla.R
@@ -26,7 +26,7 @@ iterations_per_round_random <- function(dataset, cluster_var, Id_Patient, total_
     Id_Patient <- enquo(Id_Patient)
     total_cont_per_case <- enquo(total_cont_per_case)
 
-    one_to_one = dataset %>% group_by((!!cluster_var))%>% filter(row_number() <= 2) %>% slice_sample(n = 10*total_cont_per_case, replace = FALSE) 
+    one_to_one = dataset %>% group_by((!!cluster_var))%>% filter(row_number() <= 2) %>% slice_sample(n = 10*!!total_cont_per_case, replace = FALSE) 
     dup_con = one_to_one %>% distinct() %>% group_by((!!Id_Patient)) %>% filter(n() > 1) %>% arrange((!!Id_Patient), (!!total_cont_per_case)) %>% filter(row_number() ==1)
     if (nrow(dup_con) > 0) {
         one_to_one <- anti_join(one_to_one, dup_con, by = quo_name(Id_Patient))  # library(rlang) is needed

--- a/man/optimal_matching.Rd
+++ b/man/optimal_matching.Rd
@@ -11,7 +11,8 @@ optimal_matching(
   Id_Patient,
   total_cont_per_case,
   case_control,
-  with_replacement = FALSE
+  with_replacement = FALSE,
+  randomisation = FALSE
 )
 }
 \arguments{
@@ -28,6 +29,8 @@ optimal_matching(
 \item{case_control}{a variable containing "case" and "control"}
 
 \item{with_replacement}{Use replacement or not}
+
+\item{randomisation}{are controls randomly selected from the pool of available controls for each case}
 }
 \value{
 a data frame containing the cases and the corresponding number of controls


### PR DESCRIPTION
This pull request came about as I am using this package to match on categorical variables. I have a very large pool of controls which can match my cases and there is no 'nearest neighbour' going on with categorical variables, so I wanted to add a randomisation component to the matching process in `optimal_matching`.

There is probably a more efficient/elegant way to do this, but my pull request here keeps the function `iterations_per_round` and add another function, which uses `slice_sample` from `dplyr` to randomise the controls which are selected.

Then, I modified the `optimal_matching` function to take the argument 'randomisation'. The default is `randomisation = FALSE` which will use the `iterations_per_round` function; using `randomisation = TRUE` will use the `iterations_per_round_random` function.

I modified the manual optimal_matching.Rd to reflect these changes.

I would encourage you to check my working and see that it works as intended - I am a scientist rather than a programmer, so I'm not at all sure of my work. (In fact, this is my first pull request. I figured I would create a pull request rather than an issue because I think I can better demonstrate what I want rather than describe it!)

---- summary below ----

* add iterations_per_round_random. Uses dplyr's slice_sample to randomly take controls from pool of possible controls per case
* add randomisation argument to optimal_matching. Default FALSE (use iterations_per_round); if true, use iterations_per_round_random
* modify manual to reflect these changes